### PR TITLE
Fix asset synchronization not registering due to property name typo

### DIFF
--- a/src/main/java/datameshmanager/gcp/Application.java
+++ b/src/main/java/datameshmanager/gcp/Application.java
@@ -60,7 +60,7 @@ public class Application {
   }
 
   @Bean(initMethod = "start", destroyMethod = "stop")
-  @ConditionalOnProperty(value = "datameshmanager.client.gcp.asset.enabled", havingValue = "true")
+  @ConditionalOnProperty(value = "datameshmanager.client.gcp.assets.enabled", havingValue = "true")
   public DataMeshManagerAssetsSynchronizer dataMeshManagerAssetsSynchronizer(DataMeshManagerClient client, GcpProperties gcpProperties,
       BigQuery bigQuery, TaskExecutor taskExecutor, ProjectsClient projectsClient) {
     var connectorid = gcpProperties.assets().connectorid();


### PR DESCRIPTION
## Summary
- Fixes a typo in the `@ConditionalOnProperty` annotation for the assets synchronizer bean in `Application.java`
- The annotation used `datameshmanager.client.gcp.asset.enabled` (singular) instead of `datameshmanager.client.gcp.assets.enabled` (plural)
- This caused Spring to silently skip the bean, making asset synchronization non-functional

## Root cause
Spring's `@ConditionalOnProperty` defaults to `matchIfMissing = false`. Since no property matched the singular `asset` key, the condition evaluated to false and the `dataMeshManagerAssetsSynchronizer` bean was never created — with no warning or error logged.

Fixes #44

## Test plan
- [ ] Start the connector with `DATAMESHMANAGER_CLIENT_GCP_ASSETS_ENABLED=true` and verify the `gcp-asset-synchronizer` connector registers in the logs
- [ ] Verify BigQuery assets are synced to Data Mesh Manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)