### PR TITLE
Report access provisioning state after granting and revoking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>com.entropy-data</groupId>
 			<artifactId>entropy-data-sdk</artifactId>
-			<version>0.1.2</version>
+			<version>0.2.1</version>
 		</dependency>
 
     <dependency>

--- a/src/main/java/entropydata/gcp/GcpAccessManagement.java
+++ b/src/main/java/entropydata/gcp/GcpAccessManagement.java
@@ -14,6 +14,10 @@ import entropydata.sdk.client.ApiException;
 import entropydata.sdk.client.model.Access;
 import entropydata.sdk.client.model.AccessActivatedEvent;
 import entropydata.sdk.client.model.AccessDeactivatedEvent;
+import entropydata.sdk.client.model.AccessDeprovisioningSucceededReport;
+import entropydata.sdk.client.model.AccessProvisioningFailedReport;
+import entropydata.sdk.client.model.AccessProvisioningStartedReport;
+import entropydata.sdk.client.model.AccessProvisioningSucceededReport;
 import entropydata.sdk.client.model.DataProduct;
 import entropydata.sdk.client.model.Team;
 import java.util.ArrayList;
@@ -26,6 +30,11 @@ import org.slf4j.LoggerFactory;
 public class GcpAccessManagement implements EntropyDataEventHandler {
 
   private static final Logger log = LoggerFactory.getLogger(GcpAccessManagement.class);
+
+  // Reported back to Entropy Data on every provisioning transition, so the access page shows which
+  // platform holds the grant and which component created it.
+  private static final String PLATFORM = "bigquery";
+  private static final String EXECUTOR = "Entropy Data GCP Connector";
 
   private final EntropyDataClient client;
   private final BigQuery bigQuery;
@@ -52,6 +61,7 @@ public class GcpAccessManagement implements EntropyDataEventHandler {
 
     var datasetId = findProviderDatasetId(access, client);
     if (datasetId == null) {
+      // not a BigQuery output port: another connector owns this access, so stay silent
       return;
     }
 
@@ -60,9 +70,18 @@ public class GcpAccessManagement implements EntropyDataEventHandler {
       return;
     }
 
-    authorize(datasetId, entity);
-
-    addTag(accessId, "permission-granted-on-gcp");
+    reportProvisioningStarted(access);
+    try {
+      authorize(datasetId, entity);
+      addTag(accessId, "permission-granted-on-gcp");
+    } catch (RuntimeException e) {
+      log.error("Failed to authorize access {}", accessId, e);
+      reportProvisioningFailed(access, e);
+      // Swallow after reporting: the failure is now recorded and mailed to the provider, whereas
+      // rethrowing would stall the whole event feed on this one access until it is retried.
+      return;
+    }
+    reportProvisioningSucceeded(access, reference(datasetId));
   }
 
   @Override
@@ -73,6 +92,7 @@ public class GcpAccessManagement implements EntropyDataEventHandler {
 
     var datasetId = findProviderDatasetId(access, client);
     if (datasetId == null) {
+      // not a BigQuery output port: another connector owns this access, so stay silent
       return;
     }
 
@@ -81,9 +101,80 @@ public class GcpAccessManagement implements EntropyDataEventHandler {
       return;
     }
 
-    deauthorize(datasetId, entity);
+    reportDeprovisioningStarted(access);
+    try {
+      deauthorize(datasetId, entity);
+      removeTag(accessId, "permission-granted-on-gcp");
+    } catch (RuntimeException e) {
+      log.error("Failed to deauthorize access {}", accessId, e);
+      reportDeprovisioningFailed(access, e);
+      return;
+    }
+    reportDeprovisioningSucceeded(access, reference(datasetId));
+  }
 
-    removeTag(accessId, "permission-granted-on-gcp");
+  private static String reference(DatasetId datasetId) {
+    return datasetId.getProject() + "." + datasetId.getDataset();
+  }
+
+  private void reportProvisioningStarted(Access access) {
+    safeReport(access.getId(), "provisioning-started", () ->
+        client.getAccessApi().reportProvisioningStarted(access.getId(),
+            new AccessProvisioningStartedReport().platform(PLATFORM).executor(EXECUTOR)));
+  }
+
+  private void reportProvisioningSucceeded(Access access, String reference) {
+    safeReport(access.getId(), "provisioning-succeeded", () ->
+        client.getAccessApi().reportProvisioningSucceeded(access.getId(),
+            new AccessProvisioningSucceededReport().platform(PLATFORM).executor(EXECUTOR).reference(reference)));
+  }
+
+  private void reportProvisioningFailed(Access access, Exception cause) {
+    safeReport(access.getId(), "provisioning-failed", () ->
+        client.getAccessApi().reportProvisioningFailed(access.getId(),
+            new AccessProvisioningFailedReport().platform(PLATFORM).executor(EXECUTOR).diagnostics(diagnostics(cause))));
+  }
+
+  private void reportDeprovisioningStarted(Access access) {
+    safeReport(access.getId(), "deprovisioning-started", () ->
+        client.getAccessApi().reportDeprovisioningStarted(access.getId(),
+            new AccessProvisioningStartedReport().platform(PLATFORM).executor(EXECUTOR)));
+  }
+
+  private void reportDeprovisioningSucceeded(Access access, String reference) {
+    safeReport(access.getId(), "deprovisioning-succeeded", () ->
+        client.getAccessApi().reportDeprovisioningSucceeded(access.getId(),
+            new AccessDeprovisioningSucceededReport().platform(PLATFORM).executor(EXECUTOR).reference(reference)));
+  }
+
+  private void reportDeprovisioningFailed(Access access, Exception cause) {
+    safeReport(access.getId(), "deprovisioning-failed", () ->
+        client.getAccessApi().reportDeprovisioningFailed(access.getId(),
+            new AccessProvisioningFailedReport().platform(PLATFORM).executor(EXECUTOR).diagnostics(diagnostics(cause))));
+  }
+
+  /**
+   * Reports one transition, swallowing any failure. The grant itself is the source of truth; a
+   * report that cannot be delivered (e.g. the backend predates provisioning, or the API key lacks
+   * the provider's ACCESS_EDIT permission) must not undo or block the grant.
+   */
+  private void safeReport(String accessId, String transition, ReportCall call) {
+    try {
+      call.run();
+      log.info("Reported {} for access {}", transition, accessId);
+    } catch (Exception e) {
+      log.warn("Failed to report {} for access {}: {}", transition, accessId, e.getMessage());
+    }
+  }
+
+  private static String diagnostics(Exception cause) {
+    var message = cause.getMessage();
+    return message != null ? message : cause.getClass().getSimpleName();
+  }
+
+  @FunctionalInterface
+  private interface ReportCall {
+    void run() throws ApiException;
   }
 
   public void authorize(DatasetId datasetId, Entity entity) {

--- a/src/main/java/entropydata/gcp/GcpAssetsProvider.java
+++ b/src/main/java/entropydata/gcp/GcpAssetsProvider.java
@@ -13,7 +13,7 @@ import com.google.cloud.bigquery.TableDefinition;
 import entropydata.sdk.EntropyDataAssetsProvider;
 import entropydata.sdk.EntropyDataStateRepositoryInMemory;
 import entropydata.sdk.client.model.Asset;
-import entropydata.sdk.client.model.AssetColumnsInner;
+import entropydata.sdk.client.model.AssetColumn;
 import entropydata.sdk.client.model.AssetInfo;
 import java.util.List;
 import java.util.Map;
@@ -120,7 +120,7 @@ public class GcpAssetsProvider implements EntropyDataAssetsProvider {
         FieldList fields = schema.getFields();
         if (fields != null) {
           for (Field field : fields) {
-            asset.addColumnsItem(new AssetColumnsInner()
+            asset.addColumnsItem(new AssetColumn()
                 .name(field.getName())
                 .type(field.getType().name())
                 .description(field.getDescription()));

--- a/src/test/java/entropydata/gcp/GcpAccessManagementTest.java
+++ b/src/test/java/entropydata/gcp/GcpAccessManagementTest.java
@@ -2,7 +2,9 @@ package entropydata.gcp;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -25,7 +27,11 @@ import entropydata.sdk.client.api.TeamsApi;
 import entropydata.sdk.client.model.Access;
 import entropydata.sdk.client.model.AccessActivatedEvent;
 import entropydata.sdk.client.model.AccessDeactivatedEvent;
+import entropydata.sdk.client.model.AccessDeprovisioningSucceededReport;
 import entropydata.sdk.client.model.AccessProvider;
+import entropydata.sdk.client.model.AccessProvisioningFailedReport;
+import entropydata.sdk.client.model.AccessProvisioningStartedReport;
+import entropydata.sdk.client.model.AccessProvisioningSucceededReport;
 import entropydata.sdk.client.model.DataUsageAgreementConsumer;
 import entropydata.sdk.client.model.Team;
 import java.io.IOException;
@@ -329,6 +335,97 @@ class GcpAccessManagementTest {
 
       verify(dataProductsApi, never()).getDataProduct("unknown");
       verify(bigQuery, never()).getDataset(any(DatasetId.class));
+    }
+  }
+
+  // ===== Provisioning reporting =====
+
+  @Nested
+  class ProvisioningReporting {
+
+    @Test
+    void reportsProvisioningStartedThenSucceededOnGrant() {
+      var consumer = new DataUsageAgreementConsumer().dataProductId("consumer-dp");
+      var access = buildAccess("access-1", "provider-dp", "op-1", consumer);
+      when(accessApi.getAccess("access-1")).thenReturn(access);
+      when(dataProductsApi.getDataProduct("provider-dp")).thenReturn(loadYaml("provider-dp-dps.yaml"));
+      when(dataProductsApi.getDataProduct("consumer-dp")).thenReturn(loadYaml("consumer-dp-dps.yaml"));
+      mockDataset(DatasetId.of("my-project", "my-dataset"), new ArrayList<>());
+
+      var event = new AccessActivatedEvent();
+      event.setId("access-1");
+      accessManagement.onAccessActivatedEvent(event);
+
+      // started is reported before the grant, succeeded after it, with the dataset as reference
+      var order = inOrder(accessApi);
+      order.verify(accessApi).reportProvisioningStarted(eq("access-1"), any(AccessProvisioningStartedReport.class));
+      var succeeded = ArgumentCaptor.forClass(AccessProvisioningSucceededReport.class);
+      order.verify(accessApi).reportProvisioningSucceeded(eq("access-1"), succeeded.capture());
+      assertThat(succeeded.getValue().getPlatform()).isEqualTo("bigquery");
+      assertThat(succeeded.getValue().getReference()).isEqualTo("my-project.my-dataset");
+      verify(accessApi, never()).reportProvisioningFailed(anyString(), any());
+    }
+
+    @Test
+    void reportsProvisioningFailedWhenAuthorizeThrows() {
+      var consumer = new DataUsageAgreementConsumer().dataProductId("consumer-dp");
+      var access = buildAccess("access-1", "provider-dp", "op-1", consumer);
+      when(accessApi.getAccess("access-1")).thenReturn(access);
+      when(dataProductsApi.getDataProduct("provider-dp")).thenReturn(loadYaml("provider-dp-dps.yaml"));
+      when(dataProductsApi.getDataProduct("consumer-dp")).thenReturn(loadYaml("consumer-dp-dps.yaml"));
+      // the BigQuery call throws, which the handler must report and then swallow
+      when(bigQuery.getDataset(DatasetId.of("my-project", "my-dataset")))
+          .thenThrow(new RuntimeException("dataset boom"));
+
+      var event = new AccessActivatedEvent();
+      event.setId("access-1");
+      accessManagement.onAccessActivatedEvent(event);
+
+      var order = inOrder(accessApi);
+      order.verify(accessApi).reportProvisioningStarted(eq("access-1"), any(AccessProvisioningStartedReport.class));
+      var failed = ArgumentCaptor.forClass(AccessProvisioningFailedReport.class);
+      order.verify(accessApi).reportProvisioningFailed(eq("access-1"), failed.capture());
+      assertThat(failed.getValue().getDiagnostics()).isEqualTo("dataset boom");
+      verify(accessApi, never()).reportProvisioningSucceeded(anyString(), any());
+    }
+
+    @Test
+    void reportsDeprovisioningStartedThenSucceededOnRevoke() {
+      var consumer = new DataUsageAgreementConsumer().dataProductId("consumer-dp");
+      var access = buildAccess("access-1", "provider-dp", "op-1", consumer);
+      access.setTags(new ArrayList<>(List.of("permission-granted-on-gcp")));
+      when(accessApi.getAccess("access-1")).thenReturn(access);
+      when(dataProductsApi.getDataProduct("provider-dp")).thenReturn(loadYaml("provider-dp-dps.yaml"));
+      when(dataProductsApi.getDataProduct("consumer-dp")).thenReturn(loadYaml("consumer-dp-dps.yaml"));
+      var existingAcl = Acl.of(new User("sa@project.iam.gserviceaccount.com"), Role.READER);
+      mockDataset(DatasetId.of("my-project", "my-dataset"), new ArrayList<>(List.of(existingAcl)));
+
+      var event = new AccessDeactivatedEvent();
+      event.setId("access-1");
+      accessManagement.onAccessDeactivatedEvent(event);
+
+      var order = inOrder(accessApi);
+      order.verify(accessApi).reportDeprovisioningStarted(eq("access-1"), any(AccessProvisioningStartedReport.class));
+      var succeeded = ArgumentCaptor.forClass(AccessDeprovisioningSucceededReport.class);
+      order.verify(accessApi).reportDeprovisioningSucceeded(eq("access-1"), succeeded.capture());
+      assertThat(succeeded.getValue().getReference()).isEqualTo("my-project.my-dataset");
+    }
+
+    @Test
+    void doesNotReportProvisioningWhenNotApplicable() {
+      // the output port cannot be resolved to a BigQuery dataset, so another connector owns this access
+      var consumer = new DataUsageAgreementConsumer().dataProductId("consumer-dp");
+      var access = buildAccess("access-1", "provider-dp", "nonexistent-port", consumer);
+      when(accessApi.getAccess("access-1")).thenReturn(access);
+      when(dataProductsApi.getDataProduct("provider-dp")).thenReturn(loadYaml("provider-dp-dps.yaml"));
+
+      var event = new AccessActivatedEvent();
+      event.setId("access-1");
+      accessManagement.onAccessActivatedEvent(event);
+
+      verify(accessApi, never()).reportProvisioningStarted(anyString(), any());
+      verify(accessApi, never()).reportProvisioningSucceeded(anyString(), any());
+      verify(accessApi, never()).reportProvisioningFailed(anyString(), any());
     }
   }
 


### PR DESCRIPTION
## Summary

The connector now reports the **provisioning state** of a grant back to Entropy Data, using the new `/api/access/{id}/provisioning/*` endpoints.

- **On access activation** (grant): reports `provisioning-started` before authorizing the BigQuery dataset, then `provisioning-succeeded` (with `project.dataset` as `reference`) — or `provisioning-failed` (with the exception message as `diagnostics`) if the grant throws.
- **On access deactivation** (revoke): reports the `deprovisioning-*` mirror, with the same `project.dataset` as `reference`.
- Reports are made **only when the access resolves to a BigQuery dataset**, so a connector for a different platform stays silent.
- A failed grant is **reported and then swallowed** rather than rethrown: `EntropyDataEventListener` only advances its cursor on a clean return, so rethrowing would reprocess the same access every 30s and stall the feed. The failure is recorded and mailed to the provider instead.
- Report calls are **best-effort** — a delivery failure (older backend, missing `ACCESS_EDIT` on the provider team) is logged but never undoes or blocks the grant.
- The existing `permission-granted-on-gcp` tag behavior is unchanged; provisioning reporting is layered alongside it.

Mirrors the same change in the Databricks and Snowflake connectors.

### SDK bump
Requires **entropy-data-sdk 0.2.1** for the reporting endpoints. The bump from 0.1.2 also pulls the 0.2.0 spec refresh, which renamed the generated `AssetColumnsInner` model to `AssetColumn` — updated in `GcpAssetsProvider`.

## Testing
Adds a `ProvisioningReporting` nested test class with 4 cases (started→succeeded on grant, failed-and-swallowed when the grant throws, deprovision started→succeeded, and no report when the access is not applicable). `./mvnw test` — 24 tests pass.