### PR TITLE
Pin patched Jackson versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,12 @@
 	<name>entropy-data-connector-gcp</name>
 	<description>Entropy Data Connector for GCP Integration</description>
 
+	<!-- Transitive CVE fixes. Remove once a Spring Boot release ships the patched Jackson BOMs. -->
+	<properties>
+		<jackson-bom.version>3.1.5</jackson-bom.version>
+		<jackson-2-bom.version>2.21.5</jackson-2-bom.version>
+	</properties>
+
 	<dependencies>
 
 		<dependency>


### PR DESCRIPTION
## Summary

Overrides Spring Boot's managed Jackson BOMs so `jackson-databind` resolves to the patched 2.21.5 (Jackson 2, via `entropy-data-sdk`) and 3.1.5 (Jackson 3, via `spring-boot-starter-web`). Clears all four open Dependabot alerts.

| Alert | CVE | Package | Before | After |
|---|---|---|---|---|
| #72 | CVE-2026-54515 | `com.fasterxml.jackson.core:jackson-databind` | 2.21.4 | 2.21.5 |
| #74 | GHSA-mhm7-754m-9p8w | `com.fasterxml.jackson.core:jackson-databind` | 2.21.4 | 2.21.5 |
| #75 | CVE-2026-59889 | `com.fasterxml.jackson.core:jackson-databind` | 2.21.4 | 2.21.5 |
| #76 | CVE-2026-59889 | `tools.jackson.core:jackson-databind` | 3.1.4 | 3.1.5 |

All four are transitive; neither artifact is declared in `pom.xml`. Spring Boot 4.1.0 is the latest release, so no parent bump carries the patched BOMs. Same fix already applied to the Databricks and Hive connectors.

The properties must stay in `<properties>` and must not be moved to `-D` flags. As a command-line user property, `jackson-bom.version` leaks into third-party poms — log4j's parent uses the same property name for the Jackson 2 group BOM, which makes dependency resolution fail on a nonexistent `com.fasterxml.jackson:jackson-bom:3.1.5`.

## Exposure

Not reachable in this connector; this is hygiene rather than an incident:

- No `@RestController` / `@RequestBody` exists here, so the connector never deserializes attacker-supplied JSON over HTTP.
- No `@JsonView`, `@JsonUnwrapped`, `@JsonTypeInfo`, `@JsonIgnoreProperties`, or `ACCEPT_CASE_INSENSITIVE_PROPERTIES` in `src/`, so the preconditions for all three advisories are absent.

## Testing

`./mvnw test` passes (24 tests). `./mvnw dependency:tree` confirms both artifacts resolve to the patched versions.
