### PR TITLE
Set a heap limit and report synchronization health

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ RUN useradd app
 USER app
 WORKDIR /app
 ENV OTEL_JAVAAGENT_ENABLED=false
+# Without this, the JVM caps the heap at 25% of the container memory. Overriding JAVA_TOOL_OPTIONS at
+# runtime replaces this value entirely, so any override must repeat the flags that should be kept.
+ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=60 -XX:+ExitOnOutOfMemoryError"
 ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]
 COPY --from=build /app/extracted/dependencies/ ./
 COPY --from=build /app/extracted/spring-boot-loader/ ./

--- a/README.md
+++ b/README.md
@@ -35,3 +35,22 @@ docker run \
 | `ENTROPYDATA_CLIENT_GCP_ASSETS_ENABLED`                           | `true`                             | Indicates whether GCP asset tracking is enabled.                                |
 | `ENTROPYDATA_CLIENT_GCP_ASSETS_POLLINTERVAL`                      | `PT5S`                             | Polling interval for GCP asset updates, in ISO 8601 duration format.            |
 | `ENTROPYDATA_CLIENT_GCP_ASSETS_TABLES_ALLOWLIST`                  | `*`                                | List of allowed tables for GCP asset tracking (wildcard `*` allows all tables). |
+
+## Resources
+
+The connector needs **at least 1 GB of container memory**. The image sets a heap limit accordingly:
+
+```
+JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=60 -XX:+ExitOnOutOfMemoryError
+```
+
+Without `MaxRAMPercentage`, the JVM caps the heap at 25% of the container memory. `ExitOnOutOfMemoryError` terminates the
+container instead of leaving it running with a dead synchronization thread, so that your orchestrator can restart it.
+
+Setting `JAVA_TOOL_OPTIONS` at runtime **replaces** these flags rather than adding to them. Repeat the flags you want to keep:
+
+```
+-e JAVA_TOOL_OPTIONS='-XX:MaxRAMPercentage=60 -XX:+ExitOnOutOfMemoryError -javaagent:/agent.jar'
+```
+
+Expect the container to use around 60% of its memory limit under load. Adjust memory alarms accordingly.

--- a/README.md
+++ b/README.md
@@ -54,3 +54,16 @@ Setting `JAVA_TOOL_OPTIONS` at runtime **replaces** these flags rather than addi
 ```
 
 Expect the container to use around 60% of its memory limit under load. Adjust memory alarms accordingly.
+
+### Synchronization Health
+
+The health endpoint reports whether the asset synchronization is still up to date:
+
+```
+curl http://localhost:8080/actuator/health
+```
+
+The `assetsSynchronizationHealth` component reports `DEGRADED` when the last run failed, or when no run has succeeded for three
+poll intervals, and names the failure in `lastFailure`. It is deliberately not reported as `DOWN`, and the endpoint still responds
+with 200, because the usual cause is an unavailable data platform, which restarting the container does not fix. Point liveness
+probes at `/actuator/health/liveness`, which is unaffected by the synchronization state.

--- a/src/main/java/entropydata/gcp/Application.java
+++ b/src/main/java/entropydata/gcp/Application.java
@@ -48,14 +48,22 @@ public class Application {
     return listener;
   }
 
+  @Bean
+  @ConditionalOnProperty(value = "entropydata.client.gcp.assets.enabled", havingValue = "true")
+  public AssetsSynchronizationHealth assetsSynchronizationHealth() {
+    // This connector does not configure a poll interval, so the synchronizer runs with its own default
+    return new AssetsSynchronizationHealth(null);
+  }
+
   @Bean(destroyMethod = "stop")
   @ConditionalOnProperty(value = "entropydata.client.gcp.assets.enabled", havingValue = "true")
   public EntropyDataAssetsSynchronizer entropyDataAssetsSynchronizer(EntropyDataClient client, GcpProperties gcpProperties,
-      BigQuery bigQuery, TaskExecutor taskExecutor) {
+      BigQuery bigQuery, AssetsSynchronizationHealth assetsSynchronizationHealth, TaskExecutor taskExecutor) {
     var connectorid = gcpProperties.assets().connectorid();
     var stateRepository = new EntropyDataStateRepositoryInMemory(connectorid);
     var assetsProvider = new GcpAssetsProvider(bigQuery, gcpProperties.assets().projects(), stateRepository);
-    var assetsSynchronizer = new EntropyDataAssetsSynchronizer(connectorid, client, assetsProvider);
+    var assetsSynchronizer = new EntropyDataAssetsSynchronizer(connectorid, client,
+        assetsSynchronizationHealth.wrap(assetsProvider));
     taskExecutor.execute(assetsSynchronizer::start);
     return assetsSynchronizer;
   }

--- a/src/main/java/entropydata/gcp/AssetsSynchronizationHealth.java
+++ b/src/main/java/entropydata/gcp/AssetsSynchronizationHealth.java
@@ -1,0 +1,77 @@
+package entropydata.gcp;
+
+import entropydata.sdk.EntropyDataAssetsProvider;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.boot.health.contributor.Status;
+
+/**
+ * Reports whether the asset synchronization is still up to date. It wraps the assets provider, so that a failed run, or a
+ * synchronization that no longer runs at all, becomes visible instead of the connector reporting itself as healthy.
+ */
+public class AssetsSynchronizationHealth implements EntropyDataAssetsProvider, HealthIndicator {
+
+  /**
+   * Reported instead of DOWN, because the usual cause is an unavailable data platform. Restarting the container, which is what an
+   * orchestrator does when a health check reports DOWN, does not resolve that.
+   */
+  private static final Status DEGRADED = new Status("DEGRADED");
+
+  private static final Duration DEFAULT_POLL_INTERVAL = Duration.ofHours(1);
+  private static final int MISSED_RUNS_UNTIL_DEGRADED = 3;
+
+  private final Duration degradedAfter;
+
+  private volatile EntropyDataAssetsProvider delegate;
+  private volatile Instant lastSuccessAt;
+  private volatile String lastFailure;
+
+  public AssetsSynchronizationHealth(Duration pollInterval) {
+    this.degradedAfter = Objects.requireNonNullElse(pollInterval, DEFAULT_POLL_INTERVAL).multipliedBy(MISSED_RUNS_UNTIL_DEGRADED);
+  }
+
+  /**
+   * Returns a provider that reports the outcome of every run to this indicator.
+   */
+  public EntropyDataAssetsProvider wrap(EntropyDataAssetsProvider delegate) {
+    this.delegate = delegate;
+    return this;
+  }
+
+  @Override
+  public void fetchAssets(AssetCallback callback) {
+    try {
+      delegate.fetchAssets(callback);
+      this.lastSuccessAt = Instant.now();
+      this.lastFailure = null;
+    } catch (Exception e) {
+      this.lastFailure = e.toString();
+      throw e;
+    }
+  }
+
+  @Override
+  public Health health() {
+    var lastSuccess = this.lastSuccessAt;
+    var failure = this.lastFailure;
+
+    Health.Builder health;
+    if (lastSuccess == null) {
+      health = Health.status(failure == null ? Status.UNKNOWN : DEGRADED);
+    } else if (Duration.between(lastSuccess, Instant.now()).compareTo(degradedAfter) > 0) {
+      health = Health.status(DEGRADED);
+    } else {
+      health = Health.up();
+    }
+
+    health.withDetail("lastSuccessfulSynchronizationAt", lastSuccess != null ? lastSuccess.toString() : "never");
+    health.withDetail("degradedAfter", degradedAfter.toString());
+    if (failure != null) {
+      health.withDetail("lastFailure", failure);
+    }
+    return health.build();
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,9 @@ entropydata.client.gcp.assets.projects=entropy-data-playground
 entropydata.client.gcp.assets.connectorid=gcp-asset-synchronizer
 entropydata.client.gcp.assets.pollinterval=PT5S
 entropydata.client.gcp.assets.tables.allowlist=*
+
+# The synchronization health is reported as a component of the health endpoint, which is only rendered with details enabled
+management.endpoint.health.show-details=always
+# DEGRADED ranks above UP, so that it shows in the aggregated status. It is not mapped to an error response, because
+# restarting the container does not fix an unavailable data platform.
+management.endpoint.health.status.order=DOWN,OUT_OF_SERVICE,DEGRADED,UP,UNKNOWN

--- a/src/test/java/entropydata/gcp/AssetsSynchronizationHealthTest.java
+++ b/src/test/java/entropydata/gcp/AssetsSynchronizationHealthTest.java
@@ -1,0 +1,72 @@
+package entropydata.gcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import entropydata.sdk.EntropyDataAssetsProvider;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.health.contributor.Status;
+
+class AssetsSynchronizationHealthTest {
+
+  private static final EntropyDataAssetsProvider SUCCEEDS = callback -> {
+  };
+
+  private static final EntropyDataAssetsProvider FAILS = callback -> {
+    throw new IllegalStateException("Data platform is unavailable");
+  };
+
+  private static AssetsSynchronizationHealth wrapping(EntropyDataAssetsProvider provider, Duration pollInterval) {
+    var indicator = new AssetsSynchronizationHealth(pollInterval);
+    indicator.wrap(provider);
+    return indicator;
+  }
+
+  @Test
+  void isUnknownBeforeTheFirstRunHasFinished() {
+    var health = wrapping(SUCCEEDS, Duration.ofMinutes(10)).health();
+
+    assertThat(health.getStatus()).isEqualTo(Status.UNKNOWN);
+    assertThat(health.getDetails()).containsEntry("lastSuccessfulSynchronizationAt", "never");
+  }
+
+  @Test
+  void isUpAfterASuccessfulRun() {
+    var indicator = wrapping(SUCCEEDS, Duration.ofMinutes(10));
+
+    indicator.fetchAssets(null);
+
+    assertThat(indicator.health().getStatus()).isEqualTo(Status.UP);
+  }
+
+  @Test
+  void isDegradedAfterAFailedRunAndRethrowsTheFailure() {
+    var indicator = wrapping(FAILS, Duration.ofMinutes(10));
+
+    assertThatThrownBy(() -> indicator.fetchAssets(null)).isInstanceOf(IllegalStateException.class);
+
+    var health = indicator.health();
+    assertThat(health.getStatus()).isEqualTo(new Status("DEGRADED"));
+    assertThat(health.getDetails().get("lastFailure").toString()).contains("Data platform is unavailable");
+  }
+
+  @Test
+  void isDegradedWhenTheLastSuccessfulRunIsTooLongAgo() throws Exception {
+    var indicator = wrapping(SUCCEEDS, Duration.ofMillis(1));
+
+    indicator.fetchAssets(null);
+    Thread.sleep(50);
+
+    assertThat(indicator.health().getStatus()).isEqualTo(new Status("DEGRADED"));
+  }
+
+  @Test
+  void doesNotReportDownSoThatAnUnavailableDataPlatformCannotTriggerRestarts() {
+    var indicator = wrapping(FAILS, Duration.ofMinutes(10));
+
+    assertThatThrownBy(() -> indicator.fetchAssets(null)).isInstanceOf(IllegalStateException.class);
+
+    assertThat(indicator.health().getStatus()).isNotEqualTo(Status.DOWN);
+  }
+}


### PR DESCRIPTION
## Summary

**Set a heap limit.** The image passed no heap flag, so the JVM defaulted to 25% of the container memory — a 512 MB container ran with a 128 MB heap, measured on the published image. The image now sets `-XX:MaxRAMPercentage=60`, sized against a measured non-heap footprint of roughly 190 MB. `-XX:+ExitOnOutOfMemoryError` is set as well, because an `OutOfMemoryError` otherwise kills only the worker thread that happened to be allocating, while the container keeps running and reporting itself healthy without ever synchronizing again.

**Report synchronization health.** A failed synchronization run, or a synchronization that no longer runs at all, was invisible — the health endpoint answered 200 regardless. The `assetsSynchronizationHealth` component now reports `DEGRADED` when the last run failed, or when no run has succeeded for three poll intervals, and names the failure. `DEGRADED` is deliberately not mapped to an error response: the usual cause is an unavailable data platform, and restarting the container does not fix that. Liveness probes are unaffected.

Both come out of an out-of-memory condition in the Databricks connector (DMM-523), but neither is specific to it. Same change as entropy-data/entropy-data-connector-databricks#64, which additionally fixes causes specific to Unity Catalog.

## Testing

`AssetsSynchronizationHealthTest` covers the health states, including that a failure is rethrown to the caller and never reported as `DOWN`. The health wiring was verified end to end on the Databricks connector, which uses the identical component: `/actuator/health` answers 200 with the aggregate and the component reporting `DEGRADED` and `livenessState` still `UP`.

## Notes

- Deployments need **at least 1 GB of container memory**; at 512 MB the flag has no room to help. Documented in the README.
- Memory usage rises from roughly 25% to 60% of the limit under load. Alarms thresholded below that will need retuning.
- Setting `JAVA_TOOL_OPTIONS` at runtime replaces the image value rather than merging with it. Documented in the README.
- `management.endpoint.health.show-details` is now `always`, so the health endpoint exposes component details.

## Out of scope

- Reporting connector health back to Entropy Data. The `Connector` schema has no health field, so a failing connector stays invisible in the UI even though it is now visible on its own health endpoint.