### PR TITLE
Use the released version in the examples

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       TAG_NAME:
-        description: Tag name to be used for the docker build, e.g., 0.9.0
+        description: Tag name to be used for the docker build, e.g., 0.3.0
         required: true
 
 env:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ docker run \
 Every release is published as an immutable image tag. Pin a version rather than following `latest`:
 
 ```
-entropydata/entropy-data-connector-gcp:0.9.0
+entropydata/entropy-data-connector-gcp:0.3.0
 ```
 
 | Tag | Meaning |
@@ -38,7 +38,7 @@ entropydata/entropy-data-connector-gcp:0.9.0
 Release images are signed with [cosign](https://docs.sigstore.dev/), and carry an SBOM and build provenance:
 
 ```
-cosign verify entropydata/entropy-data-connector-gcp:0.9.0 \
+cosign verify entropydata/entropy-data-connector-gcp:0.3.0 \
   --certificate-identity-regexp 'https://github.com/entropy-data/entropy-data-connector-gcp/.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```


### PR DESCRIPTION
The pinning example in the README and the input description of the release workflow named a version that was never released. Both now name 0.3.0, the first released version.