### PR TITLE
Report the version this connector runs with

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>com.entropy-data</groupId>
 			<artifactId>entropy-data-sdk</artifactId>
-			<version>0.2.1</version>
+			<version>0.3.0</version>
 		</dependency>
 
     <dependency>
@@ -70,6 +70,14 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<!-- Provides the BuildProperties bean, so the connector can report the version it runs with -->
+						<goals>
+							<goal>build-info</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/entropydata/gcp/Application.java
+++ b/src/main/java/entropydata/gcp/Application.java
@@ -6,8 +6,10 @@ import entropydata.sdk.EntropyDataAssetsSynchronizer;
 import entropydata.sdk.EntropyDataClient;
 import entropydata.sdk.EntropyDataEventListener;
 import entropydata.sdk.EntropyDataStateRepositoryInMemory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
@@ -37,13 +39,14 @@ public class Application {
   @Bean(destroyMethod = "stop")
   @ConditionalOnProperty(value = "entropydata.client.gcp.accessmanagement.enabled", havingValue = "true")
   public EntropyDataEventListener entropyDataEventListener(EntropyDataClient client, GcpProperties gcpProperties,
-      BigQuery bigQuery, TaskExecutor taskExecutor) {
+      BigQuery bigQuery, TaskExecutor taskExecutor, ObjectProvider<BuildProperties> buildProperties) {
     var connectorid = gcpProperties.accessmanagement().connectorid();
     var stateRepository = new EntropyDataStateRepositoryInMemory(connectorid);
     var eventHandler = new GcpAccessManagement(client, bigQuery, gcpProperties.accessmanagement().role(),
         gcpProperties.accessmanagement().mapping().team().customfield(),
         gcpProperties.accessmanagement().mapping().dataproduct().customfield());
-    var listener = new EntropyDataEventListener(connectorid, "accessmanagement", client, eventHandler, stateRepository);
+    var listener = new EntropyDataEventListener(connectorid, "accessmanagement", client, eventHandler, stateRepository,
+        connectorVersion(buildProperties));
     taskExecutor.execute(listener::start);
     return listener;
   }
@@ -58,12 +61,13 @@ public class Application {
   @Bean(destroyMethod = "stop")
   @ConditionalOnProperty(value = "entropydata.client.gcp.assets.enabled", havingValue = "true")
   public EntropyDataAssetsSynchronizer entropyDataAssetsSynchronizer(EntropyDataClient client, GcpProperties gcpProperties,
-      BigQuery bigQuery, AssetsSynchronizationHealth assetsSynchronizationHealth, TaskExecutor taskExecutor) {
+      BigQuery bigQuery, AssetsSynchronizationHealth assetsSynchronizationHealth, TaskExecutor taskExecutor,
+      ObjectProvider<BuildProperties> buildProperties) {
     var connectorid = gcpProperties.assets().connectorid();
     var stateRepository = new EntropyDataStateRepositoryInMemory(connectorid);
     var assetsProvider = new GcpAssetsProvider(bigQuery, gcpProperties.assets().projects(), stateRepository);
     var assetsSynchronizer = new EntropyDataAssetsSynchronizer(connectorid, client,
-        assetsSynchronizationHealth.wrap(assetsProvider));
+        assetsSynchronizationHealth.wrap(assetsProvider), connectorVersion(buildProperties));
     taskExecutor.execute(assetsSynchronizer::start);
     return assetsSynchronizer;
   }
@@ -79,4 +83,12 @@ public class Application {
     return executor;
   }
 
+  /**
+   * The version this connector runs with, so that it is visible in Entropy Data. Absent when the build information is not on the
+   * classpath, such as when the application is started from an IDE.
+   */
+  private static String connectorVersion(ObjectProvider<BuildProperties> buildProperties) {
+    var properties = buildProperties.getIfAvailable();
+    return properties != null ? properties.getVersion() : null;
+  }
 }


### PR DESCRIPTION
## Summary

`ConnectorInfo` has a `connectorVersion` field that no connector ever set, so Entropy Data could not tell which version of a connector a customer runs. That matters now that the images are versioned rather than published only as `latest`.

- the `build-info` goal generates the build information, which gives Spring Boot a `BuildProperties` bean
- its version is passed to the assets synchronizer and the event listener, which send it on registration
- the SDK is bumped to 0.3.0, which adds the constructors that accept the version

The release workflow already runs `mvn versions:set` before the image is built, so the version reported is the one the image was built from. Started outside a packaged build, for example from an IDE, no build information is on the classpath and the connector registers without a version, as before.

The SDK bump also brings in the fix that keeps the asset synchronization running after a failed run (entropy-data/entropy-data-sdk#89), which no connector has had until now.

## Testing

Verified end to end rather than only at compile time: an image built with `versions:set -DnewVersion=0.3.1-test` was run against a stubbed Entropy Data API, and the registration request it sent contained

```json
{
  "type": "assets-synchronizer",
  "connectorVersion": "0.3.1-test"
}
```